### PR TITLE
解决textVisible值为false时，进度条上有小白块的BUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ GitHub: https://github.com/GeekTR
 
 # Simple ProgessBar
 
-我这里集成了一些简单的ProgressBar，继承自官方的ProgrssBar。
+我这里集成了一些简单的ProgressBar，继承自官方的ProgressBar。
 
 他使用起来非常简单。
 
@@ -77,21 +77,21 @@ Step 2. Add the dependency
 
 HorizontalProgressBar有14个参数可配置:
 
-* Reach bar的颜色
+* reached bar的颜色
 
-    默认: 0xFFFF0000，对应的属性为tr_reach_color。
+    默认: 0xFFFF0000，对应的属性为tr_reached_color。
 
-* Reach bar的高度
+* reached bar的高度
 
-    默认，`2dp`，对应的属性为tr_reach_height。
+    默认，`2dp`，对应的属性为tr_reached_height。
 
-* UnReach bar的颜色
+* unreached bar的颜色
 
-    默认 0xFF0000FF，对应的属性为tr_unreach_color。
+    默认 0xFF0000FF，对应的属性为tr_unreached_color。
 
-* UnReach bar的高度
+* unreached bar的高度
 
-    默认，`2dp`，对应的属性为tr_unreach_height。
+    默认，`2dp`，对应的属性为tr_unreached_height。
 
 * 显示百分比的字是否可见
 
@@ -112,11 +112,11 @@ HorizontalProgressBar有14个参数可配置:
 
 * 字的显示模式
 
-    默认，Percentage，对应的属性为tr_text_show_model。分别有Percentage，Fraction和Other三种模式。Percentage表示以百分数显示，Fraction表示以分数的形式显示，Other则表示用户自定义，用户需设置ProcessTextAdapter来自定义显示内容。
+    默认，percentage，对应的属性为tr_text_show_mode。分别有percentage，fraction和other三种模式。percentage表示以百分数显示，fraction表示以分数的形式显示，other则表示用户自定义，用户需设置ProgressBarBase#ProcessTextAdapter来自定义显示内容。
     
 * 字的显示位置
 
-    默认，Center，对应的属性为tr_text_location。分别有Center,RightTop,LeftTop,RightBottom和LeftBottom五种位置。Center表示字显示在进度条中间，LeftTop表示字显示在进度条左上...
+    默认，center，对应的属性为tr_text_position。分别有center,right_top,left_top,right_bottom和left_bottom五种位置。center表示字显示在进度条中间，left_top表示字显示在进度条左上...
 
 ##### xml中配置示例
 
@@ -137,19 +137,19 @@ HorizontalProgressBar有14个参数可配置:
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="50"
-        app:tr_reach_color="@android:color/holo_blue_light"
-        app:tr_reach_height="3dp"
+        app:tr_reached_color="@android:color/holo_blue_light"
+        app:tr_reached_height="3dp"
         app:tr_text_color="@android:color/holo_red_dark"
-        app:tr_text_location="Center"
+        app:tr_text_position="center"
         app:tr_text_padding_bottom="0dp"
         app:tr_text_padding_left="5dp"
         app:tr_text_padding_right="5dp"
         app:tr_text_padding_top="0dp"
-        app:tr_text_show_model="Percentage"
+        app:tr_text_show_mode="percentage"
         app:tr_text_size="16sp"
         app:tr_text_visible="true"
-        app:tr_unreach_color="@android:color/holo_green_light"
-        app:tr_unreach_height="1dp"/>
+        app:tr_unreached_color="@android:color/holo_green_light"
+        app:tr_unreached_height="1dp"/>
 </LinearLayout>
 
 ```
@@ -157,13 +157,13 @@ HorizontalProgressBar有14个参数可配置:
 ### 也可以在java代码中配置
 
 ```java
-mProgressBar.setReachColor(Color.RED);
+mProgressBar.setReachedColor(Color.RED);
 mProgressBar.setProgress(40);
 mProgressBar.setMax(200);
-mProgressBar.setReachHeight(60);
-mProgressBar.setUnReachColor(Color.BLUE);
-mProgressBar.setUnReachHeight(50);
-mProgressBar.setTextPositon(HorizontalProgressBar.CENTER);
+mProgressBar.setReachedHeight(60);
+mProgressBar.setUnreachedColor(Color.BLUE);
+mProgressBar.setUnreachedHeight(50);
+mProgressBar.setTextPosition(HorizontalProgressBar.CENTER);
 mProgressBar.setTextPadding(10);
 ```
 
@@ -171,13 +171,13 @@ CircleProgressBar有10个参数可配置:
 
 * 和HorizontalProgressBar相同的参数
 
-    除了tr_text_location，tr_text_paing及tr_text_paing相关的四个属性外，其余的HorizontalProgressBar均适用于CircleProgressBar。
+    除了tr_text_position及tr_text_padding相关的五个属性外，其余的HorizontalProgressBar均适用于CircleProgressBar。
 
-* Reach bar的起始角度
+* reached bar的起始角度
 
     默认 , 0° ，对应的属性为tr_start_angle。
 
-* Circle的半径
+* circle的半径
 
     默认 , 30dp ，对应的属性为tr_radius。
 
@@ -200,16 +200,16 @@ CircleProgressBar有10个参数可配置:
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="0"
-        app:tr_reach_color="@android:color/holo_orange_light"
-        app:tr_reach_height="3dp"
+        app:tr_reached_color="@android:color/holo_orange_light"
+        app:tr_reached_height="3dp"
         app:tr_text_color="@android:color/black"
         app:tr_text_padding_top="5dp"
         app:tr_radius="50dp"
         app:tr_start_angle="0"
-        app:tr_text_show_model="Other"
+        app:tr_text_show_mode="other"
         app:tr_text_size="14sp"
-        app:tr_unreach_color="@android:color/holo_blue_bright"
-        app:tr_unreach_height="2dp"/>
+        app:tr_unreached_color="@android:color/holo_blue_bright"
+        app:tr_unreached_height="2dp"/>
 </LinearLayout>
 
 ```

--- a/app/src/main/java/cn/geektang/test/MainActivity.java
+++ b/app/src/main/java/cn/geektang/test/MainActivity.java
@@ -35,10 +35,10 @@ public class MainActivity extends AppCompatActivity {
             hpb1.setReachColor(Color.RED);
             hpb1.setProgress(40);
             hpb1.setMax(200);
-            hpb1.setReachHeight(60);
-            hpb1.setUnReachColor(Color.BLUE);
-            hpb1.setUnReachHeight(50);
-            hpb1.setTextPositon(HorizontalProgressBar.CENTER);
+            hpb1.setReachedHeight(60);
+            hpb1.setUnreachedColor(Color.BLUE);
+            hpb1.setUnreachedHeight(50);
+            hpb1.setTextPosition(HorizontalProgressBar.CENTER);
             hpb1.setTextPadding(10);
         }
     };

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -16,19 +16,19 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="50"
-        app:tr_reach_color="@android:color/holo_blue_light"
-        app:tr_reach_height="3dp"
+        app:tr_reached_color="@android:color/holo_blue_light"
+        app:tr_reached_height="3dp"
         app:tr_text_color="@android:color/holo_red_dark"
-        app:tr_text_location="Center"
+        app:tr_text_position="center"
         app:tr_text_padding_bottom="0dp"
         app:tr_text_padding_left="5dp"
         app:tr_text_padding_right="5dp"
         app:tr_text_padding_top="0dp"
-        app:tr_text_show_model="Percentage"
+        app:tr_text_show_mode="percentage"
         app:tr_text_size="16sp"
         app:tr_text_visible="true"
-        app:tr_unreach_color="@android:color/holo_green_light"
-        app:tr_unreach_height="1dp"/>
+        app:tr_unreached_color="@android:color/holo_green_light"
+        app:tr_unreached_height="1dp"/>
 
 
     <cn.geektang.simpleprogressbar.widget.HorizontalProgressBar
@@ -37,18 +37,18 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="0"
-        app:tr_reach_color="@android:color/holo_orange_light"
-        app:tr_reach_height="2dp"
+        app:tr_reached_color="@android:color/holo_orange_light"
+        app:tr_reached_height="2dp"
         app:tr_text_color="@android:color/black"
-        app:tr_text_location="Center"
+        app:tr_text_position="center"
         app:tr_text_padding="5dp"
         app:tr_text_padding_bottom="0dp"
         app:tr_text_padding_top="0dp"
-        app:tr_text_show_model="Fraction"
+        app:tr_text_show_mode="fraction"
         app:tr_text_size="14sp"
         app:tr_text_visible="true"
-        app:tr_unreach_color="@android:color/holo_blue_bright"
-        app:tr_unreach_height="2dp"/>
+        app:tr_unreached_color="@android:color/holo_blue_bright"
+        app:tr_unreached_height="2dp"/>
 
     <cn.geektang.simpleprogressbar.widget.HorizontalProgressBar
         android:id="@+id/hpb_3"
@@ -56,16 +56,16 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="0"
-        app:tr_reach_color="@android:color/darker_gray"
-        app:tr_reach_height="10dp"
+        app:tr_reached_color="@android:color/darker_gray"
+        app:tr_reached_height="10dp"
         app:tr_text_color="@android:color/black"
-        app:tr_text_location="Center"
+        app:tr_text_position="center"
         app:tr_text_padding="0dp"
-        app:tr_text_show_model="Percentage"
+        app:tr_text_show_mode="percentage"
         app:tr_text_size="14sp"
         app:tr_text_visible="false"
-        app:tr_unreach_color="@android:color/holo_blue_bright"
-        app:tr_unreach_height="8dp"/>
+        app:tr_unreached_color="@android:color/holo_blue_bright"
+        app:tr_unreached_height="8dp"/>
 
     <cn.geektang.simpleprogressbar.widget.HorizontalProgressBar
         android:id="@+id/hpb_4"
@@ -73,15 +73,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="0"
-        app:tr_reach_color="@android:color/holo_purple"
-        app:tr_reach_height="3dp"
+        app:tr_reached_color="@android:color/holo_purple"
+        app:tr_reached_height="3dp"
         app:tr_text_color="@android:color/black"
-        app:tr_text_location="RightBottom"
+        app:tr_text_position="right_bottom"
         app:tr_text_padding_top="5dp"
-        app:tr_text_show_model="Percentage"
+        app:tr_text_show_mode="percentage"
         app:tr_text_size="14sp"
-        app:tr_unreach_color="@android:color/holo_blue_bright"
-        app:tr_unreach_height="2dp"/>
+        app:tr_unreached_color="@android:color/holo_blue_bright"
+        app:tr_unreached_height="2dp"/>
 
     <cn.geektang.simpleprogressbar.widget.HorizontalProgressBar
         android:id="@+id/hpb_5"
@@ -89,15 +89,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="0"
-        app:tr_reach_color="@android:color/holo_orange_light"
-        app:tr_reach_height="3dp"
+        app:tr_reached_color="@android:color/holo_orange_light"
+        app:tr_reached_height="3dp"
         app:tr_text_color="@android:color/black"
-        app:tr_text_location="LeftTop"
+        app:tr_text_position="left_top"
         app:tr_text_padding_top="5dp"
-        app:tr_text_show_model="Percentage"
+        app:tr_text_show_mode="percentage"
         app:tr_text_size="14sp"
-        app:tr_unreach_color="@android:color/holo_blue_bright"
-        app:tr_unreach_height="2dp"/>
+        app:tr_unreached_color="@android:color/holo_blue_bright"
+        app:tr_unreached_height="2dp"/>
 
     <cn.geektang.simpleprogressbar.widget.CircleProgressBar
         android:id="@+id/cpb_1"
@@ -105,16 +105,16 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="0"
-        app:tr_reach_color="@android:color/holo_orange_light"
-        app:tr_reach_height="3dp"
+        app:tr_reached_color="@android:color/holo_orange_light"
+        app:tr_reached_height="3dp"
         app:tr_text_color="@android:color/black"
         app:tr_text_padding_top="5dp"
         app:tr_radius="50dp"
         app:tr_start_angle="0"
-        app:tr_text_show_model="Other"
+        app:tr_text_show_mode="other"
         app:tr_text_size="14sp"
-        app:tr_unreach_color="@android:color/holo_blue_bright"
-        app:tr_unreach_height="2dp"/>
+        app:tr_unreached_color="@android:color/holo_blue_bright"
+        app:tr_unreached_height="2dp"/>
 
     <cn.geektang.simpleprogressbar.widget.CircleProgressBar
         android:id="@+id/cpb_2"
@@ -122,15 +122,15 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:progress="50"
-        app:tr_reach_color="@android:color/holo_orange_light"
-        app:tr_reach_height="3dp"
+        app:tr_reached_color="@android:color/holo_orange_light"
+        app:tr_reached_height="3dp"
         app:tr_text_color="@android:color/black"
         app:tr_text_padding_top="5dp"
         app:tr_radius="50dp"
         app:tr_start_angle="-90"
-        app:tr_text_show_model="Percentage"
+        app:tr_text_show_mode="percentage"
         app:tr_text_size="14sp"
-        app:tr_unreach_color="@android:color/holo_blue_bright"
-        app:tr_unreach_height="2dp"/>
+        app:tr_unreached_color="@android:color/holo_blue_bright"
+        app:tr_unreached_height="2dp"/>
 
 </LinearLayout>

--- a/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/CircleProgressBar.java
+++ b/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/CircleProgressBar.java
@@ -60,8 +60,8 @@ public class CircleProgressBar extends ProgressBarBase {
 
     @Override
     protected synchronized void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-        mWidth = radius * 2 + getPaddingLeft() + getPaddingRight() + Math.max(reachHeight, unReachHeight) * 2;
-        mHeight = radius * 2 + getPaddingTop() + getPaddingBottom() + Math.max(reachHeight, unReachHeight) * 2;
+        mWidth = radius * 2 + getPaddingLeft() + getPaddingRight() + Math.max(reachedHeight, unreachedHeight) * 2;
+        mHeight = radius * 2 + getPaddingTop() + getPaddingBottom() + Math.max(reachedHeight, unreachedHeight) * 2;
         mWidth = resolveSize(mWidth, widthMeasureSpec);
         mHeight = resolveSize(mHeight, heightMeasureSpec);
 
@@ -74,28 +74,28 @@ public class CircleProgressBar extends ProgressBarBase {
     @Override
     protected synchronized void onDraw(Canvas canvas) {
         canvas.save();
-        int translateX = getPaddingLeft() + Math.max(reachHeight, unReachHeight);
-        int translateY = getPaddingTop() + Math.max(reachHeight, unReachHeight);
+        int translateX = getPaddingLeft() + Math.max(reachedHeight, unreachedHeight);
+        int translateY = getPaddingTop() + Math.max(reachedHeight, unreachedHeight);
 
         if (mRealHeight + getPaddingBottom() + getPaddingTop() < mHeight) {
-            translateY = (int) (mHeight * 0.5f - radius - Math.max(reachHeight, unReachHeight));
+            translateY = (int) (mHeight * 0.5f - radius - Math.max(reachedHeight, unreachedHeight));
         }
 
         if (mRealWidth + getPaddingLeft() + getPaddingRight() < mWidth) {
-            translateX = (int) (mWidth * 0.5f - radius - Math.max(reachHeight, unReachHeight));
+            translateX = (int) (mWidth * 0.5f - radius - Math.max(reachedHeight, unreachedHeight));
         }
         canvas.translate(translateX, translateY);
 
-        mPaint.setColor(unReachColor);
-        mPaint.setStrokeWidth(unReachHeight);
+        mPaint.setColor(unreachedColor);
+        mPaint.setStrokeWidth(unreachedHeight);
         mPaint.setStyle(Paint.Style.STROKE);
 
         float sAngle =  1.0f * getProgress() / getMax() * 360 + startAngle;
         float sweepAngle = 360 - 1.0f * getProgress() / getMax() * 360;
         canvas.drawArc(rf, sAngle, sweepAngle, false, mPaint);
 
-        mPaint.setColor(reachColor);
-        mPaint.setStrokeWidth(reachHeight);
+        mPaint.setColor(reachedColor);
+        mPaint.setStrokeWidth(reachedHeight);
         mPaint.setStyle(Paint.Style.STROKE);
         sweepAngle = (int) (1.0f * getProgress() / getMax() * 360);
         if(getProgress() > 0)

--- a/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/HorizontalProgressBar.java
+++ b/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/HorizontalProgressBar.java
@@ -238,6 +238,11 @@ public class HorizontalProgressBar extends ProgressBarBase {
 
         if(!textVisible){
             drawText = "";
+            // 重置textPadding
+            textPaddingLeft = 0;
+            textPaddingRight = 0;
+            textPaddingTop = 0;
+            textPaddingBottom = 0;
         }
         int textLength = (int) mPaint.measureText(drawText);
 

--- a/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/HorizontalProgressBar.java
+++ b/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/HorizontalProgressBar.java
@@ -17,15 +17,16 @@ import cn.geektang.simpleprogressbar.common.DensityHelper;
  */
 public class HorizontalProgressBar extends ProgressBarBase {
 
+    // text positions
     public static final int CENTER = 0;
-    public static final int RIGHTTOP = 1;
-    public static final int LEFTTOP = 2;
-    public static final int RIGHTBOTTOM = 3;
-    public static final int LEFTBOTTOM = 4;
+    public static final int RIGHT_TOP = 1;
+    public static final int LEFT_TOP = 2;
+    public static final int RIGHT_BOTTOM = 3;
+    public static final int LEFT_BOTTOM = 4;
 
     private static final int DEFAULT_TEXT_POSITION = CENTER;
 
-    private int textPositon = DEFAULT_TEXT_POSITION;
+    private int textPosition = DEFAULT_TEXT_POSITION;
 
     private Paint mPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
 
@@ -47,7 +48,7 @@ public class HorizontalProgressBar extends ProgressBarBase {
     private void obtainAttrs(Context context, AttributeSet attrs) {
         if (null != attrs) {
             TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.HorizontalProgressBar);
-            textPositon = ta.getInt(R.styleable.HorizontalProgressBar_tr_text_location, textPositon);
+            textPosition = ta.getInt(R.styleable.HorizontalProgressBar_tr_text_position, textPosition);
             ta.recycle();
         }
     }
@@ -61,7 +62,7 @@ public class HorizontalProgressBar extends ProgressBarBase {
 
         int height = 0, width = 0;
 
-        if (textPositon == CENTER) {
+        if (textPosition == CENTER) {
             height = measureCenterHeight(heightMeasureSpecSize, heightMeasureSpecMode);
             width = measureCenterWidth(widthMeasureSpecSize, widthMeasureSpecMode);
         } else {
@@ -79,9 +80,9 @@ public class HorizontalProgressBar extends ProgressBarBase {
         if (heightMeasureSpecMode == MeasureSpec.AT_MOST) {
             if(textVisible){
                 int textHeight = (int) Math.abs(mPaint.descent() - mPaint.ascent()) + textPaddingBottom + textPaddingTop;
-                height = Math.max(textHeight, Math.max(reachHeight, unReachHeight)) + getPaddingBottom() + getPaddingTop();
+                height = Math.max(textHeight, Math.max(reachedHeight, unreachedHeight)) + getPaddingBottom() + getPaddingTop();
             }else {
-                height = Math.max(reachHeight, unReachHeight) + getPaddingBottom() + getPaddingTop();
+                height = Math.max(reachedHeight, unreachedHeight) + getPaddingBottom() + getPaddingTop();
             }
         } else {
             height = heightMeasureSpecSize;
@@ -107,9 +108,9 @@ public class HorizontalProgressBar extends ProgressBarBase {
         if (heightMeasureSpecMode == MeasureSpec.AT_MOST) {
             if(textVisible){
                 int textHeight = (int) Math.abs(mPaint.descent() + mPaint.ascent()) + textPaddingBottom + textPaddingTop;
-                height = textHeight + Math.max(reachHeight, unReachHeight) + getPaddingBottom() + getPaddingTop();
+                height = textHeight + Math.max(reachedHeight, unreachedHeight) + getPaddingBottom() + getPaddingTop();
             }else{
-                height = Math.max(reachHeight, unReachHeight) + getPaddingBottom() + getPaddingTop();
+                height = Math.max(reachedHeight, unreachedHeight) + getPaddingBottom() + getPaddingTop();
             }
         } else {
             height = heightMeasureSpecSize;
@@ -127,37 +128,37 @@ public class HorizontalProgressBar extends ProgressBarBase {
         canvas.save();
         canvas.translate(getPaddingLeft(), getPaddingTop());
 
-        switch (textPositon) {
+        switch (textPosition) {
             case CENTER:
                 drawCenterBar(canvas);
                 break;
-            case RIGHTBOTTOM:
+            case RIGHT_BOTTOM:
                 drawRightBottomBar(canvas);
                 break;
-            case RIGHTTOP:
+            case RIGHT_TOP:
                 drawRightTopBar(canvas);
                 break;
-            case LEFTBOTTOM:
+            case LEFT_BOTTOM:
                 drawLeftBottomBar(canvas);
                 break;
-            case LEFTTOP:
+            case LEFT_TOP:
                 drawLetTopBar(canvas);
                 break;
             default:
-                throw new RuntimeException("No such position!");
+                throw new RuntimeException("Unsupported position!");
         }
         canvas.restore();
     }
 
     private void drawTopBar(Canvas canvas){
-        mPaint.setColor(reachColor);
-        mPaint.setStrokeWidth(reachHeight);
+        mPaint.setColor(reachedColor);
+        mPaint.setStrokeWidth(reachedHeight);
         int reachBarLength = (int) (1.0f * getProgress() / getMax() * mRealWidth);
-        int drawY = (int) (mRealHeight - Math.max(reachHeight * 0.5f,unReachHeight * 0.5f));
+        int drawY = (int) (mRealHeight - Math.max(reachedHeight * 0.5f,unreachedHeight * 0.5f));
         canvas.drawLine(0,drawY,reachBarLength,drawY,mPaint);
 
-        mPaint.setColor(unReachColor);
-        mPaint.setStrokeWidth(unReachHeight);
+        mPaint.setColor(unreachedColor);
+        mPaint.setStrokeWidth(unreachedHeight);
         canvas.drawLine(reachBarLength,drawY,mRealWidth,drawY,mPaint);
     }
 
@@ -176,14 +177,14 @@ public class HorizontalProgressBar extends ProgressBarBase {
     }
 
     private void drawBottomBar(Canvas canvas){
-        mPaint.setColor(reachColor);
-        mPaint.setStrokeWidth(reachHeight);
+        mPaint.setColor(reachedColor);
+        mPaint.setStrokeWidth(reachedHeight);
         int reachBarLength = (int) (1.0f * getProgress() / getMax() * mRealWidth);
-        int drawY = (int) Math.max(reachHeight * 0.5f,unReachHeight * 0.5f);
+        int drawY = (int) Math.max(reachedHeight * 0.5f,unreachedHeight * 0.5f);
         canvas.drawLine(0,drawY,reachBarLength,drawY,mPaint);
 
-        mPaint.setColor(unReachColor);
-        mPaint.setStrokeWidth(unReachHeight);
+        mPaint.setColor(unreachedColor);
+        mPaint.setStrokeWidth(unreachedHeight);
         canvas.drawLine(reachBarLength,drawY,mRealWidth,drawY,mPaint);
     }
 
@@ -226,13 +227,13 @@ public class HorizontalProgressBar extends ProgressBarBase {
             String drawText = getProcessText();
             int drawLength = (int) mPaint.measureText(drawText);
             int drawX = mRealWidth - textPaddingRight - drawLength;
-            int drawY = (int) (Math.max(reachHeight,unReachHeight) + textPaddingTop - mPaint.descent() - mPaint.ascent());
+            int drawY = (int) (Math.max(reachedHeight,unreachedHeight) + textPaddingTop - mPaint.descent() - mPaint.ascent());
             canvas.drawText(drawText,drawX,drawY,mPaint);
         }
     }
 
     private void drawCenterBar(Canvas canvas) {
-        boolean drawUnRech = true;
+        boolean drawUnreached = true;
         mPaint.setTextSize(textSize);
         String drawText = getProcessText();
 
@@ -246,14 +247,14 @@ public class HorizontalProgressBar extends ProgressBarBase {
         }
         int textLength = (int) mPaint.measureText(drawText);
 
-        mPaint.setColor(reachColor);
-        mPaint.setStrokeWidth(reachHeight);
+        mPaint.setColor(reachedColor);
+        mPaint.setStrokeWidth(reachedHeight);
         int reachBarLength = (int) (1.0f * getProgress() / getMax() * mRealWidth);
         int drawY = (int) (1.0f * mRealHeight / 2);
 
         if(reachBarLength + textLength + textPaddingLeft > mRealWidth){
             reachBarLength = mRealWidth - textLength - textPaddingLeft;
-            drawUnRech = false;
+            drawUnreached = false;
         }
         canvas.drawLine(0, drawY, reachBarLength, drawY, mPaint);
 
@@ -262,24 +263,24 @@ public class HorizontalProgressBar extends ProgressBarBase {
         drawY = (int) (drawY - (mPaint.descent() + mPaint.ascent()) / 2);
         canvas.drawText(drawText,drawX,drawY,mPaint);
 
-        if(drawUnRech){
-            mPaint.setColor(unReachColor);
-            mPaint.setStrokeWidth(unReachHeight);
+        if(drawUnreached){
+            mPaint.setColor(unreachedColor);
+            mPaint.setStrokeWidth(unreachedHeight);
             int startX = reachBarLength + textPaddingLeft + textPaddingRight + textLength;
             drawY = (int) (1.0f * mRealHeight / 2);
             canvas.drawLine(startX,drawY,mRealWidth,drawY,mPaint);
         }
     }
 
-    public int getTextPositon() {
-        return textPositon;
+    public int getTextPosition() {
+        return textPosition;
     }
 
-    public void setTextPositon(int textPositon) {
-        if(textPositon < CENTER && textPositon > LEFTBOTTOM){
-            throw  new RuntimeException("No such position!");
+    public void setTextPosition(int textPosition) {
+        if(textPosition < CENTER && textPosition > LEFT_BOTTOM){
+            throw  new RuntimeException("Unsupported position!");
         }
-        this.textPositon = textPositon;
+        this.textPosition = textPosition;
         postInvalidate();
     }
 }

--- a/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/ProgressBarBase.java
+++ b/simpleprogressbar/src/main/java/cn/geektang/simpleprogressbar/widget/ProgressBarBase.java
@@ -15,33 +15,36 @@ import cn.geektang.simpleprogressbar.common.DensityHelper;
  * Date   :2016/7/16
  */
 public abstract class ProgressBarBase extends ProgressBar {
+    // text mode
     public static final int PERCENTAGE = 0;
     public static final int FRACTION = 1;
     public static final int OTHER = 2;
 
-    protected static final int DEFAULT_REACH_COLOR = Color.RED;
-    protected static final int DEFAULT_REACH_HEIGHT = 2;//dp
-    protected static final int DEFAULT_UNREACH_COLOR = Color.BLUE;
-    protected static final int DEFAULT_UNREACH_HEIGHT = 2;//dp
-    protected static final int DEFAULT_TEXT_SIZE = 14;//sp
-    protected static final int DEFULT_TEXT_COLOR = Color.GREEN;
-    protected static final boolean DEFAULT_IS_SHOW_TEXT = true;
-    protected static final int DEFAULT_TEXT_PADDING = 3;//dp
-    protected static final int DEFAULT_TEXT_MODEL = PERCENTAGE;
+    // default attrs
+    protected static final int DEFAULT_REACHED_COLOR = Color.RED;
+    protected static final int DEFAULT_REACHED_HEIGHT = 2;    // dp
+    protected static final int DEFAULT_UNREACHED_COLOR = Color.BLUE;
+    protected static final int DEFAULT_UNREACHED_HEIGHT = 2;    // dp
+    protected static final int DEFAULT_TEXT_SIZE = 14;  // sp
+    protected static final int DEFAULT_TEXT_COLOR = Color.GREEN;
+    protected static final boolean DEFAULT_SHOW_TEXT = true;
+    protected static final int DEFAULT_TEXT_PADDING = 3;    // dp
+    protected static final int DEFAULT_TEXT_MODE = PERCENTAGE;
 
-    protected int reachColor = DEFAULT_REACH_COLOR;
-    protected int reachHeight = DEFAULT_REACH_HEIGHT;
-    protected int unReachColor = DEFAULT_UNREACH_COLOR;
-    protected int unReachHeight = DEFAULT_UNREACH_HEIGHT;
+    // attrs
+    protected int reachedColor = DEFAULT_REACHED_COLOR;
+    protected int reachedHeight = DEFAULT_REACHED_HEIGHT;
+    protected int unreachedColor = DEFAULT_UNREACHED_COLOR;
+    protected int unreachedHeight = DEFAULT_UNREACHED_HEIGHT;
     protected int textSize = DEFAULT_TEXT_SIZE;
-    protected int textColor = DEFULT_TEXT_COLOR;
-    protected boolean textVisible = DEFAULT_IS_SHOW_TEXT;
+    protected int textColor = DEFAULT_TEXT_COLOR;
+    protected boolean textVisible = DEFAULT_SHOW_TEXT;
     protected int textPadding = DEFAULT_TEXT_PADDING;
     protected int textPaddingLeft = DEFAULT_TEXT_PADDING;
     protected int textPaddingRight = DEFAULT_TEXT_PADDING;
     protected int textPaddingTop = DEFAULT_TEXT_PADDING;
     protected int textPaddingBottom = DEFAULT_TEXT_PADDING;
-    protected int textModel = DEFAULT_TEXT_MODEL;
+    protected int textMode = DEFAULT_TEXT_MODE;
 
     protected int mRealHeight;
     protected int mRealWidth;
@@ -67,16 +70,16 @@ public abstract class ProgressBarBase extends ProgressBar {
         if (null != attrs) {
             TypedArray ta = context.obtainStyledAttributes(attrs, R.styleable.ProgressBarBase);
 
-            reachColor = ta.getColor(R.styleable.ProgressBarBase_tr_reach_color, reachColor);
-            reachHeight = (int) ta.getDimension(
-                    R.styleable.ProgressBarBase_tr_reach_height,
-                    DensityHelper.dip2px(context, reachHeight));
+            reachedColor = ta.getColor(R.styleable.ProgressBarBase_tr_reached_color, reachedColor);
+            reachedHeight = (int) ta.getDimension(
+                    R.styleable.ProgressBarBase_tr_reached_height,
+                    DensityHelper.dip2px(context, reachedHeight));
 
 
-            unReachColor = ta.getColor(R.styleable.ProgressBarBase_tr_unreach_color, unReachColor);
-            unReachHeight = (int) ta.getDimension(
-                    R.styleable.ProgressBarBase_tr_unreach_height,
-                    DensityHelper.dip2px(context, unReachHeight));
+            unreachedColor = ta.getColor(R.styleable.ProgressBarBase_tr_unreached_color, unreachedColor);
+            unreachedHeight = (int) ta.getDimension(
+                    R.styleable.ProgressBarBase_tr_unreached_height,
+                    DensityHelper.dip2px(context, unreachedHeight));
 
             textSize = (int) ta.getDimension(
                     R.styleable.ProgressBarBase_tr_text_size,
@@ -104,7 +107,7 @@ public abstract class ProgressBarBase extends ProgressBar {
                     R.styleable.ProgressBarBase_tr_text_padding_bottom,
                     textPaddingBottom);
 
-            textModel = ta.getInt(R.styleable.ProgressBarBase_tr_text_show_model, textModel);
+            textMode = ta.getInt(R.styleable.ProgressBarBase_tr_text_show_mode, textMode);
 
             ta.recycle();
         }
@@ -117,15 +120,15 @@ public abstract class ProgressBarBase extends ProgressBar {
 
     protected String getProcessText() {
         String text = null;
-        if (textModel == PERCENTAGE) {
+        if (textMode == PERCENTAGE) {
             text = (int) (1.0f * getProgress() / getMax() * 100) + "%";
-        } else if (textModel == FRACTION) {
+        } else if (textMode == FRACTION) {
             text = getProgress() + "/" + getMax();
         } else {
             if (null != processTextAdapter) {
                 text = processTextAdapter.getCustomProcessText(getProgress(), getMax());
             } else {
-                throw new RuntimeException("You must set ProcessTextAdapter!");
+                throw new RuntimeException("A ProgressBarBase#ProcessTextAdapter is required!");
             }
         }
         return text;
@@ -142,39 +145,39 @@ public abstract class ProgressBarBase extends ProgressBar {
             onProcessChangeListener.onProcessChange(progress, getMax());
     }
 
-    public int getReachColor() {
-        return reachColor;
+    public int getReachedColor() {
+        return reachedColor;
     }
 
-    public void setReachColor(int reachColor) {
-        this.reachColor = reachColor;
+    public void setReachColor(int reachedColor) {
+        this.reachedColor = reachedColor;
         postInvalidate();
     }
 
-    public int getReachHeight() {
-        return reachHeight;
+    public int getReachedHeight() {
+        return reachedHeight;
     }
 
-    public void setReachHeight(int reachHeight) {
-        this.reachHeight = reachHeight;
+    public void setReachedHeight(int reachedHeight) {
+        this.reachedHeight = reachedHeight;
         postInvalidate();
     }
 
-    public int getUnReachColor() {
-        return unReachColor;
+    public int getUnReachedColor() {
+        return unreachedColor;
     }
 
-    public void setUnReachColor(int unReachColor) {
-        this.unReachColor = unReachColor;
+    public void setUnreachedColor(int unreachedColor) {
+        this.unreachedColor = unreachedColor;
         postInvalidate();
     }
 
-    public int getUnReachHeight() {
-        return unReachHeight;
+    public int getUnreachedHeight() {
+        return unreachedHeight;
     }
 
-    public void setUnReachHeight(int unReachHeight) {
-        this.unReachHeight = unReachHeight;
+    public void setUnreachedHeight(int unreachedHeight) {
+        this.unreachedHeight = unreachedHeight;
         postInvalidate();
     }
 
@@ -255,15 +258,15 @@ public abstract class ProgressBarBase extends ProgressBar {
     }
 
 
-    public int getTextModel() {
-        return textModel;
+    public int getTextMode() {
+        return textMode;
     }
 
-    public void setTextModel(int textModel) {
-        if (textModel < PERCENTAGE && textModel > OTHER) {
-            throw new RuntimeException("No such model!");
+    public void setTextMode(int textMode) {
+        if (textMode < PERCENTAGE && textMode > OTHER) {
+            throw new RuntimeException("Unsupported mode!");
         }
-        this.textModel = textModel;
+        this.textMode = textMode;
         postInvalidate();
     }
 

--- a/simpleprogressbar/src/main/res/values/attrs.xml
+++ b/simpleprogressbar/src/main/res/values/attrs.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="tr_reach_color" format="color"></attr>
-    <attr name="tr_reach_height" format="dimension"></attr>
-    <attr name="tr_unreach_color" format="color"></attr>
-    <attr name="tr_unreach_height" format="dimension"></attr>
+    <attr name="tr_reached_color" format="color"></attr>
+    <attr name="tr_reached_height" format="dimension"></attr>
+    <attr name="tr_unreached_color" format="color"></attr>
+    <attr name="tr_unreached_height" format="dimension"></attr>
     <attr name="tr_text_size" format="dimension"></attr>
     <attr name="tr_text_color" format="color"></attr>
     <attr name="tr_text_visible" format="boolean"></attr>
@@ -12,31 +12,31 @@
     <attr name="tr_text_padding_right" format="dimension"></attr>
     <attr name="tr_text_padding_top" format="dimension"></attr>
     <attr name="tr_text_padding_bottom" format="dimension"></attr>
-    <attr name="tr_text_show_model" format="enum">
-        <enum name="Percentage" value="0"></enum>
-        <enum name="Fraction" value="1"></enum>
-        <enum name="Other" value="2"></enum>
+    <attr name="tr_text_show_mode" format="enum">
+        <enum name="percentage" value="0"></enum>
+        <enum name="fraction" value="1"></enum>
+        <enum name="other" value="2"></enum>
     </attr>
-    <attr name="tr_text_location" format="enum">
-        <enum name="Center" value="0"></enum>
-        <enum name="RightTop" value="1"></enum>
-        <enum name="LeftTop" value="2"></enum>
-        <enum name="RightBottom" value="3"></enum>
-        <enum name="LeftBottom" value="4"></enum>
+    <attr name="tr_text_position" format="enum">
+        <enum name="center" value="0"></enum>
+        <enum name="right_top" value="1"></enum>
+        <enum name="left_top" value="2"></enum>
+        <enum name="right_bottom" value="3"></enum>
+        <enum name="left_bottom" value="4"></enum>
     </attr>
     <attr name="tr_start_angle" format="float"></attr>
     <attr name="tr_radius" format="dimension"></attr>
 
     <declare-styleable name="ProgressBarBase">
-        <attr name="tr_reach_color"></attr>
-        <attr name="tr_reach_height"></attr>
-        <attr name="tr_unreach_color"></attr>
-        <attr name="tr_unreach_height"></attr>
+        <attr name="tr_reached_color"></attr>
+        <attr name="tr_reached_height"></attr>
+        <attr name="tr_unreached_color"></attr>
+        <attr name="tr_unreached_height"></attr>
         <attr name="tr_text_size"></attr>
         <attr name="tr_text_color"></attr>
         <attr name="tr_text_visible"></attr>
         <attr name="tr_text_padding"></attr>
-        <attr name="tr_text_show_model"></attr>
+        <attr name="tr_text_show_mode"></attr>
         <attr name="tr_text_padding_left"></attr>
         <attr name="tr_text_padding_right"></attr>
         <attr name="tr_text_padding_top"></attr>
@@ -44,7 +44,7 @@
     </declare-styleable>
 
     <declare-styleable name="HorizontalProgressBar">
-        <attr name="tr_text_location"></attr>
+        <attr name="tr_text_position"></attr>
     </declare-styleable>
 
     <declare-styleable name="CircleProgressBar">


### PR DESCRIPTION
当textVisible值指定为false时，进度条有小白块，效果如下：
![image](https://cloud.githubusercontent.com/assets/12081818/22729395/849a67c6-ee1d-11e6-809f-fa80fc21a382.png)

修改后效果：
![image](https://cloud.githubusercontent.com/assets/12081818/22729426/a1dea3e2-ee1d-11e6-94bf-787f1757aada.png)
